### PR TITLE
feat(rpaas-api): update chart version and cluster role

### DIFF
--- a/charts/rpaas-api/Chart.yaml
+++ b/charts/rpaas-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rpaas-api
 description: The API of Tsuru/RPaaS
 type: application
-version: 0.7.3
+version: 0.7.4
 appVersion: 0.49.5

--- a/charts/rpaas-api/templates/cluster_role.yaml
+++ b/charts/rpaas-api/templates/cluster_role.yaml
@@ -74,6 +74,13 @@ rules:
   - get
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - update
+- apiGroups:
   - nginx.tsuru.io
   resources:
   - nginxes


### PR DESCRIPTION
Bump rpaas-api chart version to 0.7.4. Extend ClusterRole to allow 'get' and 'update' verbs on 'deployments' resources in the 'apps' API group. This enables the API to manage deployment resources as required.