### PR TITLE
add job resource in batch API group

### DIFF
--- a/charts/tsuru-api/templates/rbac.yaml
+++ b/charts/tsuru-api/templates/rbac.yaml
@@ -53,6 +53,7 @@ rules:
   - batch
   resources:
   - cronjobs
+  - jobs
   verbs:
   - "*"
 


### PR DESCRIPTION
Fix this error:
```
unable to read job tsuru-handson-cronjob: 500 Internal Server Error: jobs.batch is forbidden: User "system:serviceaccount:tsuru-system:tsuru-api" cannot list resource "jobs" in API group "batch" in the namespace "tsuru-devsecops"
```