### PR TITLE
update-crds: add helm.sh/resource-policy: keep annotation to all CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: update-crds update-slis
 update-crds:
 	@for chart in nginx-operator rpaas-operator acl-operator ; \
 		 do \
-		   kustomize build github.com/tsuru/$${chart}//config/crd/?ref=main > ./charts/$${chart}/crds/crds.yaml ;\
+		   kustomize build ./kustomize/$${chart} > ./charts/$${chart}/crds/crds.yaml ;\
 		   crd=$$(<./charts/$${chart}/crds/crds.yaml) ;\
 		   echo "{{- if .Values.installCRDs }}" > ./charts/$${chart}/templates/crds.yaml ;\
 		   echo "$$crd" >> ./charts/$${chart}/templates/crds.yaml ;\

--- a/charts/acl-operator/crds/crds.yaml
+++ b/charts/acl-operator/crds/crds.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    helm.sh/resource-policy: keep
   creationTimestamp: null
   name: acldnsentries.extensions.tsuru.io
 spec:
@@ -38,6 +39,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    helm.sh/resource-policy: keep
   creationTimestamp: null
   name: acls.extensions.tsuru.io
 spec:
@@ -70,6 +72,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    helm.sh/resource-policy: keep
   creationTimestamp: null
   name: rpaasinstanceaddresses.extensions.tsuru.io
 spec:
@@ -106,6 +109,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    helm.sh/resource-policy: keep
   creationTimestamp: null
   name: tsuruappaddresses.extensions.tsuru.io
 spec:

--- a/charts/acl-operator/templates/crds.yaml
+++ b/charts/acl-operator/templates/crds.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    helm.sh/resource-policy: keep
   creationTimestamp: null
   name: acldnsentries.extensions.tsuru.io
 spec:
@@ -39,6 +40,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    helm.sh/resource-policy: keep
   creationTimestamp: null
   name: acls.extensions.tsuru.io
 spec:
@@ -71,6 +73,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    helm.sh/resource-policy: keep
   creationTimestamp: null
   name: rpaasinstanceaddresses.extensions.tsuru.io
 spec:
@@ -107,6 +110,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    helm.sh/resource-policy: keep
   creationTimestamp: null
   name: tsuruappaddresses.extensions.tsuru.io
 spec:

--- a/charts/nginx-operator/crds/crds.yaml
+++ b/charts/nginx-operator/crds/crds.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    helm.sh/resource-policy: keep
   name: nginxes.nginx.tsuru.io
 spec:
   group: nginx.tsuru.io

--- a/charts/nginx-operator/crds/crds.yaml
+++ b/charts/nginx-operator/crds/crds.yaml
@@ -12,8 +12,8 @@ spec:
     listKind: NginxList
     plural: nginxes
     singular: nginx
-  scope: Namespaced
   preserveUnknownFields: false
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.currentReplicas

--- a/charts/nginx-operator/templates/crds.yaml
+++ b/charts/nginx-operator/templates/crds.yaml
@@ -13,8 +13,8 @@ spec:
     listKind: NginxList
     plural: nginxes
     singular: nginx
-  scope: Namespaced
   preserveUnknownFields: false
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.currentReplicas

--- a/charts/nginx-operator/templates/crds.yaml
+++ b/charts/nginx-operator/templates/crds.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    helm.sh/resource-policy: keep
   name: nginxes.nginx.tsuru.io
 spec:
   group: nginx.tsuru.io

--- a/charts/rpaas-operator/crds/crds.yaml
+++ b/charts/rpaas-operator/crds/crds.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.0
+    helm.sh/resource-policy: keep
   name: rpaasflavors.extensions.tsuru.io
 spec:
   group: extensions.tsuru.io
@@ -6734,6 +6735,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.0
+    helm.sh/resource-policy: keep
   name: rpaasinstances.extensions.tsuru.io
 spec:
   group: extensions.tsuru.io
@@ -13470,6 +13472,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.0
+    helm.sh/resource-policy: keep
   name: rpaasplans.extensions.tsuru.io
 spec:
   group: extensions.tsuru.io
@@ -13692,6 +13695,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.0
+    helm.sh/resource-policy: keep
   name: rpaasvalidations.extensions.tsuru.io
 spec:
   group: extensions.tsuru.io

--- a/charts/rpaas-operator/templates/crds.yaml
+++ b/charts/rpaas-operator/templates/crds.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.0
+    helm.sh/resource-policy: keep
   name: rpaasflavors.extensions.tsuru.io
 spec:
   group: extensions.tsuru.io
@@ -6735,6 +6736,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.0
+    helm.sh/resource-policy: keep
   name: rpaasinstances.extensions.tsuru.io
 spec:
   group: extensions.tsuru.io
@@ -13471,6 +13473,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.0
+    helm.sh/resource-policy: keep
   name: rpaasplans.extensions.tsuru.io
 spec:
   group: extensions.tsuru.io
@@ -13693,6 +13696,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.0
+    helm.sh/resource-policy: keep
   name: rpaasvalidations.extensions.tsuru.io
 spec:
   group: extensions.tsuru.io

--- a/kustomize/acl-operator/kustomization.yaml
+++ b/kustomize/acl-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- github.com/tsuru/acl-operator//config/crd/?ref=main
+commonAnnotations:
+  helm.sh/resource-policy: keep

--- a/kustomize/nginx-operator/kustomization.yaml
+++ b/kustomize/nginx-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- github.com/tsuru/nginx-operator//config/crd/?ref=main
+commonAnnotations:
+  helm.sh/resource-policy: keep

--- a/kustomize/nginx-operator/kustomization.yaml
+++ b/kustomize/nginx-operator/kustomization.yaml
@@ -2,3 +2,13 @@ resources:
 - github.com/tsuru/nginx-operator//config/crd/?ref=main
 commonAnnotations:
   helm.sh/resource-policy: keep
+patches:
+- target:
+    kind: CustomResourceDefinition
+  patch: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: nginxes.nginx.tsuru.io
+    spec:
+      preserveUnknownFields: false

--- a/kustomize/rpaas-operator/kustomization.yaml
+++ b/kustomize/rpaas-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- github.com/tsuru/rpaas-operator//config/crd/?ref=main
+commonAnnotations:
+  helm.sh/resource-policy: keep


### PR DESCRIPTION
This prevents Helm from deleting CRDs during `helm uninstall`, which could cause data loss by removing all custom resources in the cluster.

The annotation is now applied via kustomize overlays instead of post-processing with yq. Each operator has its own kustomization.yaml under kustomize/{chart}/ that references the upstream CRD source and applies commonAnnotations, keeping the Makefile simpler.