### PR TITLE
feat(acl-operator): add externalSecrets support for tsuru token

### DIFF
--- a/charts/acl-operator/templates/deployment.yaml
+++ b/charts/acl-operator/templates/deployment.yaml
@@ -45,7 +45,14 @@ spec:
           - name: TSURU_TARGET
             value: {{ .Values.tsuru.address }}
           - name: TSURU_TOKEN
+            {{- if .Values.externalSecrets.enabled }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.externalSecrets.secretName }}
+                key: {{ .Values.externalSecrets.secretKey }}
+            {{- else }}
             value: {{ .Values.tsuru.token }}
+            {{- end }}
 
           {{- with .Values.aclapi.address }}
           - name: ACL_API_ADDRESS

--- a/charts/acl-operator/values.yaml
+++ b/charts/acl-operator/values.yaml
@@ -11,6 +11,11 @@ tsuru:
   address: ""
   token: ""
 
+externalSecrets:
+  enabled: false
+  secretName: "acl-tsuru-token"
+  secretKey: "tsuru-token"
+
 aclapi:
   address: ""
   user: ""


### PR DESCRIPTION
When externalSecrets.enabled is true, TSURU_TOKEN is read from an existing cluster Secret via valueFrom.secretKeyRef instead of a plain value from values.yaml.