### PR TITLE
feat(deploy-agent): support volumeClaimTemplates as both list and map

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,33 @@ on:
       - main
 
 jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+
+      - name: Detect charts with tests
+        id: charts
+        run: |
+          charts=$(find charts -type d -name tests | sed 's|/tests$||' | sort -u | tr '\n' ' ')
+          echo "list=${charts}" >> "$GITHUB_OUTPUT"
+
+      - name: Run helm unittest
+        run: |
+          for chart in ${{ steps.charts.outputs.list }}; do
+            echo "==> Testing ${chart}"
+            helm unittest "${chart}"
+          done
+
   release:
+    needs: unittest
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/charts/deploy-agent/.helmignore
+++ b/charts/deploy-agent/.helmignore
@@ -21,3 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
+tests/

--- a/charts/deploy-agent/templates/statefulset.yaml
+++ b/charts/deploy-agent/templates/statefulset.yaml
@@ -15,8 +15,13 @@ spec:
   {{- with .Values.updateStategy }}
   updateStategy: {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.volumeClaimTemplates }}
-  volumeClaimTemplates: {{- toYaml . | nindent 2 }}
+  {{- if and (kindIs "slice" .Values.volumeClaimTemplates) .Values.volumeClaimTemplates }}
+  volumeClaimTemplates: {{- toYaml .Values.volumeClaimTemplates | nindent 2 }}
+  {{- else if .Values.volumeClaimTemplates }}
+  volumeClaimTemplates:
+  {{- range $name, $value := .Values.volumeClaimTemplates }}
+  - {{- toYaml $value | nindent 4 }}
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/charts/deploy-agent/templates/statefulset.yaml
+++ b/charts/deploy-agent/templates/statefulset.yaml
@@ -152,8 +152,8 @@ spec:
       nodeSelector: {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.affinity }}
-      affinity: {{- toYaml . | nindent 6 }}
+      affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
-      tolerations: {{- toYaml . | nindent 6 }}
+      tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/deploy-agent/tests/statefulset_test.yaml
+++ b/charts/deploy-agent/tests/statefulset_test.yaml
@@ -32,11 +32,6 @@ tests:
               storage: 100Gi
           storageClassName: premium-rwo
     asserts:
-      - isKind:
-          of: StatefulSet
-      - equal:
-          path: metadata.name
-          value: deploy-agent
       - equal:
           path: spec.volumeClaimTemplates
           value:
@@ -68,11 +63,6 @@ tests:
                 storage: 100Gi
             storageClassName: premium-rwo
     asserts:
-      - isKind:
-          of: StatefulSet
-      - equal:
-          path: metadata.name
-          value: deploy-agent
       - equal:
           path: spec.volumeClaimTemplates
           value:

--- a/charts/deploy-agent/tests/statefulset_test.yaml
+++ b/charts/deploy-agent/tests/statefulset_test.yaml
@@ -1,0 +1,89 @@
+suite: test statefulset
+templates:
+  - statefulset.yaml
+release:
+  name: deploy-agent
+tests:
+  - it: should work
+    set:
+      deployAgent.image.tag: latest
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: deploy-agent
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: tsuru/deploy-agent:latest
+
+  - it: with volumeClaimTemplates list
+    set:
+      volumeClaimTemplates:
+      - metadata:
+          labels:
+            excluded-from-alerts: "true"
+          name: buildkit-data
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 100Gi
+          storageClassName: premium-rwo
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: deploy-agent
+      - equal:
+          path: spec.volumeClaimTemplates
+          value:
+          - metadata:
+              labels:
+                excluded-from-alerts: "true"
+              name: buildkit-data
+            spec:
+              accessModes:
+              - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 100Gi
+              storageClassName: premium-rwo
+
+  - it: with volumeClaimTemplates map
+    set:
+      volumeClaimTemplates:
+        buildkit-data:
+          metadata:
+            labels:
+              excluded-from-alerts: "true"
+            name: buildkit-data
+          spec:
+            accessModes:
+            - ReadWriteOnce
+            resources:
+              requests:
+                storage: 100Gi
+            storageClassName: premium-rwo
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: deploy-agent
+      - equal:
+          path: spec.volumeClaimTemplates
+          value:
+          - metadata:
+              labels:
+                excluded-from-alerts: "true"
+              name: buildkit-data
+            spec:
+              accessModes:
+              - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 100Gi
+              storageClassName: premium-rwo              

--- a/charts/deploy-agent/tests/statefulset_test.yaml
+++ b/charts/deploy-agent/tests/statefulset_test.yaml
@@ -76,4 +76,48 @@ tests:
               resources:
                 requests:
                   storage: 100Gi
-              storageClassName: premium-rwo              
+              storageClassName: premium-rwo
+
+  - it: with tolerations
+    set:
+      tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "deploy-agent"
+        effect: "NoSchedule"
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+          - key: "dedicated"
+            operator: "Equal"
+            value: "deploy-agent"
+            effect: "NoSchedule"
+
+  - it: with affinity
+    set:
+      affinity:
+        nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: "cloud.google.com/gke-spot"
+                  operator: "NotIn"
+                  values: ["true"]
+                - key: "cloud.google.com/gke-preemptible"
+                  operator: "NotIn"
+                  values: ["true"]
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity
+          value:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: "cloud.google.com/gke-spot"
+                    operator: "NotIn"
+                    values: ["true"]
+                  - key: "cloud.google.com/gke-preemptible"
+                    operator: "NotIn"
+                    values: ["true"]


### PR DESCRIPTION
Allow volumeClaimTemplates to be defined either as a YAML list (existing behavior) or as a map keyed by name, enabling easier per-environment overrides via Helm values merging. Adds helm unit tests covering both input formats.